### PR TITLE
Fix writeable flag

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-rules (2.2.1) stable; urgency=medium
+
+  * Fix writeable flag on creation of virtual device
+
+ -- Roman Kubar <r.kubar@wirenboard.ru>  Mon, 16 Mar 2020 22:53:08 +0300
+
 wb-rules (2.2) stable; urgency=medium
 
   * release version 2.2

--- a/wbrules/engine.go
+++ b/wbrules/engine.go
@@ -1269,7 +1269,7 @@ func (engine *RuleEngine) DefineVirtualDevice(devId string, obj objx.Map) error 
 		// set readonly/writeable flag
 		if ctrlReadonly {
 			args.SetReadonly(ctrlReadonly)
-		} else {
+		} else if hasWriteable {
 			args.SetWritable(true)
 		}
 


### PR DESCRIPTION
Before this  fix there was logic like this:
```
if type of control is switch or pushbutton -- then in mqtt writeable=1 (defaults in wbgo)
if no value was set to writeable -- then in mqtt writeable=1
if value to writeable set to true -- then in mqtt writeable=1
if value to writeable set to false -- then in mqtt writeable=0
```
    
After this fix:
```
if type of control is switch or pushbutton -- then in mqtt writeable=1 (defaults in wbgo)
if no value was set to writeable -- then in mqtt writeable=0 (defaults in wbgo)
f value to writeable set to true -- then in mqtt writeable=1
if value to writeable set to false -- then in mqtt writeable=0
```